### PR TITLE
Do not use seq for :=

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -194,7 +194,7 @@ module.exports = grammar({
 
     // -- Variables
 
-    inferred_type: $ => seq(':', '='),
+    inferred_type: $ => choice(':=', seq(':', '=')),
 
     _variable_assignment: $ => seq('=', $._expression),
     _variable_inferred_type_assignment: $ => seq($.inferred_type, $._expression),


### PR DESCRIPTION
`seq` causes issues with parsing using the following rules:

```
(inferred_type) @operator
["," "." ":"] @punctuation.delimiter
```

Before:

![изображение](https://user-images.githubusercontent.com/22453358/115152426-ac788a80-a079-11eb-874b-45e66fd70996.png)

After:

![изображение](https://user-images.githubusercontent.com/22453358/115152403-9074e900-a079-11eb-8494-a5d2d69f88a0.png)
