### PR TITLE
Gdquest/add region support

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -60,6 +60,11 @@ module.exports = grammar({
     // However, it breaks nested if else chains.
     /* ":", */
     $._body_end,
+
+    // Region markers for code folding. We need to add them here because they are
+    // parsed by the scanner.c file and not by the grammar.
+    $._region_start,
+    $._region_end,
   ],
 
   inline: ($) => [$._simple_statement, $._compound_statement],
@@ -341,7 +346,8 @@ module.exports = grammar({
         $.constructor_definition,
         $.class_definition,
         $.enum_definition,
-        $.match_statement
+        $.match_statement,
+        $.region
       ),
 
     if_statement: ($) =>
@@ -433,6 +439,18 @@ module.exports = grammar({
       ),
 
     match_body: ($) => seq($._indent, repeat1($.pattern_section), $._dedent),
+
+    // Code region syntax, parsed to offer code folding support (these are #region and #endregion marks)
+    region: ($) =>
+      seq(
+        $._region_start,
+        optional($.region_name),
+        $._newline,
+        repeat($._statement),
+        $._region_end
+      ),
+
+    region_name: ($) => /[^\r\n]+/,
 
     // Sources:
     // - https://github.com/godotengine/godot-proposals/issues/4775

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -307,7 +307,7 @@ bool tree_sitter_gdscript_external_scanner_scan(void *payload, TSLexer *lexer,
                 // Region delimiters are always on their own line, so we
                 // check for trailing whitespace and line returns after the token to determine
                 // if we have a valid region or endregion token.
-                if (is_region && look_ahead_string(lexer, "region")) {
+                if (valid_symbols[REGION_START] && is_region && look_ahead_string(lexer, "region")) {
                     if (lexer->lookahead == ' ' || lexer->lookahead == '\t' ||
                         lexer->lookahead == '\n' || lexer->lookahead == '\r' ||
                         lexer->eof(lexer)) {
@@ -315,7 +315,7 @@ bool tree_sitter_gdscript_external_scanner_scan(void *payload, TSLexer *lexer,
                         lexer->result_symbol = REGION_START;
                         return true;
                     }
-                } else if (is_endregion && look_ahead_string(lexer, "endregion")) {
+                } else if (valid_symbols[REGION_END] && is_endregion && look_ahead_string(lexer, "endregion")) {
                     if (lexer->lookahead == ' ' || lexer->lookahead == '\t' ||
                         lexer->lookahead == '\n' || lexer->lookahead == '\r' ||
                         lexer->eof(lexer)) {

--- a/test/corpus/regions.txt
+++ b/test/corpus/regions.txt
@@ -1,0 +1,129 @@
+=====================================
+Empty region
+=====================================
+
+#region empty
+#endregion
+
+---
+
+(source
+  (region
+    (region_name)
+))
+
+=====================================
+Basic anonymous region with code
+=====================================
+
+#region
+func _ready() -> void:
+    pass
+#endregion
+
+---
+
+(source
+  (region
+    (function_definition
+      (name)
+      (parameters)
+      (type (identifier))
+      (body (pass_statement)))))
+
+=====================================
+Named region with more code
+=====================================
+
+#region process
+func _process(delta: float) -> void:
+    position += velocity * delta
+#endregion
+
+---
+
+(source
+  (region
+    (region_name)
+    (function_definition
+      (name)
+      (parameters
+        (typed_parameter
+          (identifier)
+          (type (identifier))))
+      (type (identifier))
+      (body
+        (expression_statement
+          (augmented_assignment
+            (identifier)
+            (binary_operator
+              (identifier)
+              (identifier))))))))
+
+=====================================
+Region with leading indentation
+=====================================
+
+func _physics_process(delta: float) -> void:
+    #region movement
+    pass
+    #endregion
+
+---
+
+(source
+  (function_definition
+    (name)
+    (parameters
+        (typed_parameter
+        (identifier)
+        (type (identifier))))
+    (type (identifier))
+    (body
+      (region
+        (region_name)
+        (pass_statement)
+    ))))
+
+=====================================
+Two sibling regions
+=====================================
+
+#region variables
+var health: int = 100
+var speed: float = 5.0
+#endregion
+
+#region functions
+func take_damage(amount) -> void:
+    health -= amount
+#endregion
+
+---
+
+(source
+  (region
+    (region_name)
+    (variable_statement
+      (name)
+      (type
+        (identifier))
+      (integer))
+    (variable_statement
+      (name)
+      (type
+        (identifier))
+      (float)))
+  (region
+    (region_name)
+    (function_definition
+      (name)
+      (parameters
+        (identifier))
+      (type
+        (identifier))
+      (body
+        (expression_statement
+          (augmented_assignment
+            (identifier)
+            (identifier)))))))


### PR DESCRIPTION
This is an attempt at implementing #32. There is a detail I don't know yet, what the valid_symbols lookup is for, but otherwise as it's a scanner-based parser it was intuitive enough and I pushed toward getting something working.

As it's more or less test driven plus parsing of these region markers is not too complicated (line matching `#region.*$` or `#endregion\s*$`). One thing I'm not sure right now as I check this PR is if a special check is wanted in case a user writes invalid regions like `var test #region` -> I leveraged the existing comment parsing section so right now I think this will be treated as a region marker while in the Godot editor, it does get highlighted, but it does not give you a fold.

I have to tap out right now to clean the house and buy groceries so I'm pushing for a first review but I'll keep some time free on my next day off if this needs more work.

Feel free to make changes directly by the way! Or tell me if I should change anything.