### PR TITLE
Simplify comment and region parsing, fix comment indentation edge cases

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -55,11 +55,6 @@ module.exports = grammar({
     // However, it breaks nested if else chains.
     /* ":", */
     $._body_end,
-
-    // Region markers for code folding. We need to add them here because they are
-    // parsed by the scanner.c file and not by the grammar.
-    $._region_start,
-    $._region_end,
   ],
 
   inline: ($) => [$._simple_statement, $._compound_statement],
@@ -86,6 +81,12 @@ module.exports = grammar({
     // named symbol of a statement
     // such as a function name or class name
     name: ($) => $._identifier,
+    // Code region syntax, parsed to offer code folding support (these are #region and #endregion marks)
+    region_start: ($) =>
+      seq(token(prec(100, "#region")), optional($.region_label)),
+    region_end: ($) =>
+      token(seq(prec(100, "#endregion"), optional(/[^\r\n]*/))),
+    region_label: ($) => /[^\r\n]+/,
     comment: ($) => token(seq("#", /.*/)),
     true: ($) => "true",
     false: ($) => "false",
@@ -231,6 +232,8 @@ module.exports = grammar({
         $.break_statement,
         $.breakpoint_statement,
         $.continue_statement,
+        $.region_start,
+        $.region_end,
       ),
 
     expression_statement: ($) =>
@@ -383,7 +386,6 @@ module.exports = grammar({
         $.class_definition,
         $.enum_definition,
         $.match_statement,
-        $.region,
       ),
 
     if_statement: ($) =>
@@ -475,18 +477,6 @@ module.exports = grammar({
       ),
 
     match_body: ($) => seq($._indent, repeat1($.pattern_section), $._dedent),
-
-    // Code region syntax, parsed to offer code folding support (these are #region and #endregion marks)
-    region: ($) =>
-      seq(
-        $._region_start,
-        optional($.region_label),
-        $._newline,
-        repeat($._statement),
-        $._region_end,
-      ),
-
-    region_label: ($) => /[^\r\n]+/,
 
     // Sources:
     // - https://github.com/godotengine/godot-proposals/issues/4775

--- a/grammar.js
+++ b/grammar.js
@@ -40,13 +40,6 @@ module.exports = grammar({
     $._string_name_start,
     $._node_path_start,
 
-    // Mark comments as external tokens so that the external scanner is always
-    // invoked, even if no external token is expected. This allows for better
-    // error recovery, because the external scanner can maintain the overall
-    // structure by returning dedent tokens whenever a dedent occurs, even
-    // if no dedent is expected.
-    $.comment,
-
     // Allow the external scanner to check for the validity of closing brackets
     // so that it can avoid returning dedent tokens between brackets.
     "]",

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -48,7 +48,6 @@ enum TokenType {
     STRING_END,
     STRING_NAME_START,
     NODE_PATH_START,
-    COMMENT,
     CLOSE_PAREN,
     CLOSE_BRACKET,
     CLOSE_BRACE,
@@ -154,7 +153,6 @@ typedef struct {
 typedef struct {
     indent_vec *indents;
     delimiter_vec *delimiters;
-    bool has_inline_comment;
 } Scanner;
 
 static inline void advance(TSLexer *lexer) { lexer->advance(lexer, false); }
@@ -266,14 +264,14 @@ bool tree_sitter_gdscript_external_scanner_scan(void *payload, TSLexer *lexer,
 
     lexer->mark_end(lexer);
 
+
+
     bool found_end_of_line = false;
     uint32_t indent_length = 0;
-    int32_t first_comment_indent_length = -1;
     for (;;) {
         if (lexer->lookahead == '\n') {
             found_end_of_line = true;
             indent_length = 0;
-            scanner->has_inline_comment = false;
             skip(lexer);
         } else if (lexer->lookahead == ' ') {
             indent_length++;
@@ -285,36 +283,18 @@ bool tree_sitter_gdscript_external_scanner_scan(void *payload, TSLexer *lexer,
             indent_length += 8;
             skip(lexer);
         } else if (lexer->lookahead == '#') {
-            uint32_t comment_column = lexer->get_column(lexer);
-            // We check if the comment marker comes right after the indent to
-            // determine if it's located at the start of the line. If so it's a
-            // standalone comment. Otherwise, it's inline with code.
-            bool is_comment_at_line_start = (comment_column == indent_length);
-            bool is_region_marker = false;
-
-            // Check for #region and #endregion in priority before handling the token as a comment.
+            // Check for #region and #endregion markers, as currently we do not treat them the same as normal comments.
             if (valid_symbols[REGION_START] || valid_symbols[REGION_END]) {
-                // We first walk over the # character
                 advance(lexer);
 
-                // We check if the next characters might be the start or end of a region keyword to filter out
-                // comments that are not region markers before making more checks.
-                bool is_region = (lexer->lookahead == 'r');
-                bool is_endregion = (lexer->lookahead == 'e');
+                bool is_potential_region_start = (lexer->lookahead == 'r');
+                bool is_potential_endregion_start = (lexer->lookahead == 'e');
 
-                // Region delimiters are always on their own line. They have an
-                // optional label after the keyword that is ignored by the
-                // GDScript parser (so the opening and closing labels don't have
-                // to match).
-                if (valid_symbols[REGION_START] && is_region && look_ahead_string(lexer, "region")) {
+                if (valid_symbols[REGION_START] && is_potential_region_start && look_ahead_string(lexer, "region")) {
                     lexer->mark_end(lexer);
                     lexer->result_symbol = REGION_START;
                     return true;
-                } else if (valid_symbols[REGION_END] && is_endregion && look_ahead_string(lexer, "endregion")) {
-                    // We want to capture the opening label if it is present in
-                    // case someone wants to use it for text editor outline for
-                    // example, but ignore the closing label. Here we consume
-                    // the entire line because of that.
+                } else if (valid_symbols[REGION_END] && is_potential_endregion_start && look_ahead_string(lexer, "endregion")) {
                     while (lexer->lookahead && lexer->lookahead != '\n' && lexer->lookahead != '\r' && !lexer->eof(lexer)) {
                         advance(lexer);
                     }
@@ -324,16 +304,20 @@ bool tree_sitter_gdscript_external_scanner_scan(void *payload, TSLexer *lexer,
                 }
             }
 
-            // We were not looking at a region or endregion token, handle as regular comment
-            if (first_comment_indent_length == -1 && is_comment_at_line_start) {
-                first_comment_indent_length = (int32_t)indent_length;
-            } else if (!is_comment_at_line_start) {
-                scanner->has_inline_comment = true;
+            // The current scanner can scan past a line return into a comment.
+            // In that case we want to stop processing here, since it means
+            // we're looking potentially at a comment on the next line compared
+            // to the starting point of this scan.
+            if (!found_end_of_line) {
+                break;
             }
+
             while (lexer->lookahead && lexer->lookahead != '\n') {
                 skip(lexer);
             }
-            skip(lexer);
+            if (lexer->lookahead == '\n') {
+                skip(lexer);
+            }
             indent_length = 0;
         } else if (lexer->lookahead == '\\') {
             skip(lexer);
@@ -365,25 +349,7 @@ bool tree_sitter_gdscript_external_scanner_scan(void *payload, TSLexer *lexer,
                 return true;
             }
 
-            // Check if the lexer is expecting a DEDENT token, but we're not
-            // within brackets or expecting a string.
-            bool dedent_explicitly_valid = valid_symbols[DEDENT];
-            bool not_expecting_strings_or_in_brackets = !valid_symbols[NEWLINE] &&
-                                     !valid_symbols[STRING_START] &&
-                                     !valid_symbols[STRING_NAME_START] &&
-                                     !valid_symbols[NODE_PATH_START] &&
-                                     !within_brackets;
-            bool should_generate_dedent = dedent_explicitly_valid || not_expecting_strings_or_in_brackets;
-            bool indentation_has_decreased = indent_length < current_indent_length;
-
-            // Wait to create a dedent token until we've consumed any comments
-            // whose indentation matches the current block. Also delay dedent if
-            // we have inline comments to allow them to be associated with the
-            // current scope.
-            bool comments_allow_dedent = first_comment_indent_length < (int32_t)current_indent_length &&
-                                       !scanner->has_inline_comment;
-
-            if (should_generate_dedent && indentation_has_decreased && comments_allow_dedent) {
+            if (valid_symbols[DEDENT] && indent_length < current_indent_length) {
                 VEC_POP(scanner->indents);
                 lexer->result_symbol = DEDENT;
                 return true;
@@ -427,10 +393,9 @@ bool tree_sitter_gdscript_external_scanner_scan(void *payload, TSLexer *lexer,
         }
     }
 
-    if (first_comment_indent_length == -1 &&
-            (valid_symbols[STRING_START] ||
-            valid_symbols[STRING_NAME_START] ||
-            valid_symbols[NODE_PATH_START])) {
+    if (valid_symbols[STRING_START] ||
+        valid_symbols[STRING_NAME_START] ||
+        valid_symbols[NODE_PATH_START]) {
         Delimiter delimiter = new_delimiter();
 
         bool has_flags = true;
@@ -496,10 +461,6 @@ unsigned tree_sitter_gdscript_external_scanner_serialize(void *payload,
         buffer[size++] = (char)scanner->indents->data[iter];
     }
 
-    if (size < TREE_SITTER_SERIALIZATION_BUFFER_SIZE) {
-        buffer[size++] = scanner->has_inline_comment ? 1 : 0;
-    }
-
     return size;
 }
 
@@ -511,7 +472,6 @@ void tree_sitter_gdscript_external_scanner_deserialize(void *payload,
     VEC_CLEAR(scanner->delimiters);
     VEC_CLEAR(scanner->indents);
     VEC_PUSH(scanner->indents, 0);
-    scanner->has_inline_comment = false;
 
     if (length > 0) {
         size_t size = 0;
@@ -524,17 +484,9 @@ void tree_sitter_gdscript_external_scanner_deserialize(void *payload,
             size += delimiter_count;
         }
 
-        // Deserialize the indents. Right now it's all except the last byte
-        // which is the has_inline_comment field.
-        for (; size < length - 1; size++) {
+        // Deserialize the indents
+        for (; size < length; size++) {
             VEC_PUSH(scanner->indents, (unsigned char)buffer[size]);
-        }
-
-        // Now we got all indents, deserialize the has_inline_comment field,
-        // which is the last byte in the buffer. It's a char so we need to
-        // convert it to a bool.
-        if (size < length) {
-            scanner->has_inline_comment = buffer[size++] != 0;
         }
 
         assert(size == length);

--- a/test/corpus/comments.txt
+++ b/test/corpus/comments.txt
@@ -1,0 +1,258 @@
+=====================================
+Inline Comments in Set and Get Blocks
+=====================================
+
+var prop = 10: # var comment
+	set(value): # set comment
+		prop = value
+	get: # get comment
+		return prop
+
+---
+
+(source
+  (variable_statement
+    name: (name)
+    value: (integer)
+    setget: (setget
+      (comment)
+      set: (set_body
+        (parameters
+          (identifier))
+        (comment)
+        body: (body
+          (expression_statement
+            (assignment
+              left: (identifier)
+              right: (identifier)))))
+      get: (get_body
+        (comment)
+        body: (body
+          (return_statement
+            (identifier)))))))
+
+=====================================
+Inline Comments in Class and Function Definitions
+=====================================
+
+class InnerClass: # class comment
+	pass
+
+func _init(): # constructor comment
+	pass
+
+func foo(): # func comment
+    pass
+
+---
+
+(source
+  (class_definition
+    (name)
+    (comment)
+    (body
+      (pass_statement)))
+  (constructor_definition
+    (parameters)
+    (comment)
+    (body
+      (pass_statement)))
+  (function_definition
+    (name)
+    (parameters)
+    (comment)
+    (body
+      (pass_statement))))
+
+
+=====================================
+Inline Comments in If/Elif/Else
+=====================================
+
+func test():
+	if true: # if comment
+		pass
+	elif false: # elif comment
+		pass
+	else: # else comment
+		pass
+
+---
+
+(source
+  (function_definition
+    (name)
+    (parameters)
+    (body
+      (if_statement
+        (true)
+        (comment)
+        (body
+          (pass_statement))
+        (elif_clause
+          (false)
+          (comment)
+          (body
+            (pass_statement)))
+        (else_clause
+          (comment)
+          (body
+            (pass_statement)))))))
+
+=====================================
+Inline Comments in Match Block
+=====================================
+
+func test():
+	match 0: # match comment
+		1: # case comment
+			pass
+		_: # default comment
+			pass
+
+---
+
+(source
+  (function_definition
+    (name)
+    (parameters)
+    (body
+      (match_statement
+        (integer)
+        (comment)
+        (match_body
+          (pattern_section
+            (integer)
+            (comment)
+            (body
+              (pass_statement)))
+          (pattern_section
+            (identifier)
+            (comment)
+            (body
+              (pass_statement))))))))
+
+=====================================
+Inline Comments in For Loop
+=====================================
+
+func test():
+	for i in 10: # for comment
+		pass
+
+---
+
+(source
+  (function_definition
+    (name)
+    (parameters)
+    (body
+      (for_statement
+        (identifier)
+        (integer)
+        (comment)
+        (body
+          (pass_statement))))))
+
+=====================================
+Inline Comments in While Loop
+=====================================
+
+func test():
+	while false: # while comment
+		pass
+
+---
+
+(source
+  (function_definition
+    (name)
+    (parameters)
+    (body
+      (while_statement
+        (false)
+        (comment)
+        (body
+          (pass_statement))))))
+
+=====================================
+Inline Comments in Lambda
+=====================================
+
+func test():
+	var lam = func(): # lambda comment
+		pass
+
+---
+
+(source
+  (function_definition
+    (name)
+    (parameters)
+    (body
+      (variable_statement
+        (name)
+        (lambda
+          (parameters)
+          (comment)
+          (body
+            (pass_statement)))))))
+
+=====================================
+Inline Trailing Comments
+=====================================
+
+func test():
+	return # function trailing comment at end
+
+---
+
+(source
+  (function_definition
+    (name)
+    (parameters)
+    (body
+      (return_statement)
+      (comment))))
+
+=====================================
+Inline Trailing Comments After Class Definition
+=====================================
+
+class MyClass:
+	pass # class trailing comment
+
+---
+
+(source
+  (class_definition
+    (name)
+    (body
+      (pass_statement)
+      (comment))))
+
+=====================================
+Inline Comments After Control Flow
+=====================================
+
+func test():
+	for x in y:
+		continue
+
+	# Comment
+	pass
+
+---
+
+(source
+  (function_definition
+    (name)
+    (parameters)
+    (body
+      (for_statement
+        (identifier)
+        (identifier)
+        (body
+          (continue_statement)))
+      (comment)
+      (pass_statement))))

--- a/test/corpus/regions.txt
+++ b/test/corpus/regions.txt
@@ -84,8 +84,8 @@ func _physics_process(delta: float) -> void:
     (body
       (region_start
         (region_label))
-      (pass_statement)
-      (region_end))))
+      (pass_statement)))
+  (region_end))
 
 =====================================
 Region: Two sibling regions

--- a/test/corpus/regions.txt
+++ b/test/corpus/regions.txt
@@ -1,5 +1,5 @@
 =====================================
-Empty region
+Region: Empty region
 =====================================
 
 #region empty
@@ -8,12 +8,12 @@ Empty region
 ---
 
 (source
-  (region
-    (region_label)
-))
+  (region_start
+    (region_label))
+  (region_end))
 
 =====================================
-Basic anonymous region with code
+Region: Basic anonymous region with code
 =====================================
 
 #region
@@ -24,15 +24,16 @@ func _ready() -> void:
 ---
 
 (source
-  (region
-    (function_definition
-      (name)
-      (parameters)
-      (type (identifier))
-      (body (pass_statement)))))
+  (region_start)
+  (function_definition
+    (name)
+    (parameters)
+    (type (identifier))
+    (body (pass_statement)))
+  (region_end))
 
 =====================================
-Named region with more code
+Region: Named region with more code
 =====================================
 
 #region process
@@ -43,25 +44,26 @@ func _process(delta: float) -> void:
 ---
 
 (source
-  (region
-    (region_label)
-    (function_definition
-      (name)
-      (parameters
-        (typed_parameter
+  (region_start
+    (region_label))
+  (function_definition
+    (name)
+    (parameters
+      (typed_parameter
+        (identifier)
+        (type (identifier))))
+    (type (identifier))
+    (body
+      (expression_statement
+        (augmented_assignment
           (identifier)
-          (type (identifier))))
-      (type (identifier))
-      (body
-        (expression_statement
-          (augmented_assignment
+          (binary_operator
             (identifier)
-            (binary_operator
-              (identifier)
-              (identifier))))))))
+            (identifier))))))
+  (region_end))
 
 =====================================
-Region with leading indentation
+Region: Region with leading indentation
 =====================================
 
 func _physics_process(delta: float) -> void:
@@ -80,13 +82,13 @@ func _physics_process(delta: float) -> void:
         (type (identifier))))
     (type (identifier))
     (body
-      (region
-        (region_label)
-        (pass_statement)
-    ))))
+      (region_start
+        (region_label))
+      (pass_statement)
+      (region_end))))
 
 =====================================
-Two sibling regions
+Region: Two sibling regions
 =====================================
 
 #region variables
@@ -102,28 +104,30 @@ func take_damage(amount) -> void:
 ---
 
 (source
-  (region
-    (region_label)
-    (variable_statement
-      (name)
-      (type
-        (identifier))
-      (integer))
-    (variable_statement
-      (name)
-      (type
-        (identifier))
-      (float)))
-  (region
-    (region_label)
-    (function_definition
-      (name)
-      (parameters
-        (identifier))
-      (type
-        (identifier))
-      (body
-        (expression_statement
-          (augmented_assignment
-            (identifier)
-            (identifier)))))))
+  (region_start
+    (region_label))
+  (variable_statement
+    (name)
+    (type
+      (identifier))
+    (integer))
+  (variable_statement
+    (name)
+    (type
+      (identifier))
+    (float))
+  (region_end)
+  (region_start
+    (region_label))
+  (function_definition
+    (name)
+    (parameters
+      (identifier))
+    (type
+      (identifier))
+    (body
+      (expression_statement
+        (augmented_assignment
+          (identifier)
+          (identifier)))))
+  (region_end))


### PR DESCRIPTION
This simplifies comment parsing by moving logic out of scanner.c, and adds test cases for comments.

Close #42
Close #53 

---

Should allow addressing https://github.com/GDQuest/GDScript-formatter/issues/18 and https://github.com/GDQuest/GDScript-formatter/issues/55