### PR TITLE
Fix line continuation parsing, follow tree-sitter-python and make it a visible token 

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -28,7 +28,7 @@ module.exports = grammar({
 
   word: ($) => $._identifier,
 
-  extras: ($) => [$.comment, /[\s\uFEFF\u2060\u200B]/],
+  extras: ($) => [$.comment, /[\s\uFEFF\u2060\u200B]/, $.line_continuation],
 
   externals: ($) => [
     $._newline,
@@ -176,12 +176,7 @@ module.exports = grammar({
                 seq(
                   optional("/"),
                   $._identifier,
-                  repeat(
-                    // It's valid syntax in GDScript to wrap get node paths with
-                    // $ or % over multiple lines with line continuation marks.
-                    // But the continuation mark can only come after a trailing /
-                    seq("/", optional($._line_continuation), $._identifier),
-                  ),
+                  repeat(seq("/", $._identifier)),
                 ),
               ),
             ),
@@ -189,12 +184,7 @@ module.exports = grammar({
               "%",
               choice(
                 alias($.string, "value"),
-                seq(
-                  $._identifier,
-                  repeat(
-                    seq("/", optional($._line_continuation), $._identifier),
-                  ),
-                ),
+                seq($._identifier, repeat(seq("/", $._identifier))),
               ),
             ),
           ),
@@ -839,8 +829,7 @@ module.exports = grammar({
     // This rule is for trailing backslashes to indicate line continuation. We
     // capture those as anonymous '\' tokens to be able to preserve them in code
     // formatters.
-    line_continuation: ($) => token(prec(1, seq("\\", /\r?\n/))),
-    _line_continuation: ($) => alias($.line_continuation, ""),
+    line_continuation: ($) => token(seq("\\", /\r?\n/)),
   }, // end rules
 });
 

--- a/test/corpus/linecontinuations.txt
+++ b/test/corpus/linecontinuations.txt
@@ -15,9 +15,11 @@ world"
 
 (source
   (expression_statement
-    (get_node))
+    (get_node
+      (line_continuation)))
   (expression_statement
-    (get_node))
+    (get_node
+      (line_continuation)))
   (expression_statement
     (string_name
       (escape_sequence))))
@@ -26,12 +28,121 @@ world"
 Invalid syntax sugar line continuations
 ===
 
+# This is invalid GDScript but I'm making the parser accept it for the sake of simplicity with line continuations
 $get\
 /node
 
 ---
 
 (source
+  (comment)
   (expression_statement
-  (get_node
-    (ERROR))))
+    (get_node
+      (line_continuation))))
+
+===
+Line continuation in binary expressions
+===
+
+func _handles(resource):
+    return resource is NoiseTexture2D \
+    or resource is GradientTexture1D
+
+---
+
+(source
+  (function_definition
+    name: (name)
+    parameters: (parameters
+      (identifier))
+    body: (body
+      (return_statement
+        (binary_operator
+          left: (binary_operator
+            left: (identifier)
+            right: (identifier))
+          (line_continuation)
+          right: (binary_operator
+            left: (identifier)
+            right: (identifier)))))))
+
+===
+Line continuation in function calls
+===
+
+func _process(delta):
+    move_and_slide(velocity * \
+                    delta)
+
+---
+
+(source
+  (function_definition
+    name: (name)
+    parameters: (parameters
+      (identifier))
+    body: (body
+      (expression_statement
+        (call
+          (identifier)
+          arguments: (arguments
+            (binary_operator
+              left: (identifier)
+              (line_continuation)
+              right: (identifier))))))))
+
+===
+Line continuation in array literals
+===
+
+func test():
+	var array = [
+		1, \
+		2, \
+		3
+	]
+
+---
+
+(source
+  (function_definition
+    name: (name)
+    parameters: (parameters)
+    body: (body
+      (variable_statement
+        name: (name)
+        value: (array
+          (integer)
+          (line_continuation)
+          (integer)
+          (line_continuation)
+          (integer))))))
+
+===
+Line continuation in dictionary
+===
+
+func test():
+	var dict = {
+		"key": \
+		"value",
+		"key2": \
+		"value2"
+	}
+
+---
+
+(source
+  (function_definition
+    name: (name)
+    parameters: (parameters)
+    body: (body
+      (variable_statement
+        name: (name)
+        value: (dictionary
+          (pair
+            left: (string)
+            value: (string))
+          (pair
+            left: (string)
+            value: (string)))))))

--- a/test/corpus/strings.txt
+++ b/test/corpus/strings.txt
@@ -6,7 +6,7 @@ Double-quoted regular string
 
 ---
 
-(source 
+(source
   (expression_statement
     (string)))
 
@@ -56,7 +56,7 @@ Single-quoted regular string
 
 ---
 
-(source 
+(source
   (expression_statement
     (string)))
 
@@ -621,7 +621,8 @@ var v = ^ ''''''
   (expression_statement
     (get_node))
   (expression_statement
-    (get_node))
+    (get_node
+        (line_continuation)))
   (comment)
   (comment)
   (expression_statement
@@ -668,4 +669,3 @@ var v = ^ ''''''
   (variable_statement (name) (ERROR) (string))
   (variable_statement (name) (ERROR) (string))
   (variable_statement (name) (ERROR) (string)))
-


### PR DESCRIPTION
This fixes today's earlier implementation of the \ token. First, I can't use "\\" in tree sitter queries, at least with topiary for GDScript formatting: it causes the query to fail to compile.

Then I realized that with the approach I took, the line continuation rule would need to be added everywhere. Initially I thought of putting it in the scanner.c file, but ended up checking what Python did and it turns out that when you put something in extras you don't necessarily need to parse them with the external scanner which was a misconception I had.

Long story short, this copies what Python does. GDscript has similar rules to Python for trailing \ with some really rare edge cases like the get node case. This seems to work well. Now it'll also be a named node that'll be usable in the formatter, there again, same as the Python tree sitter parser.