### PR TITLE
Fix Go binding to include external scanner

### DIFF
--- a/bindings/go/binding.go
+++ b/bindings/go/binding.go
@@ -2,7 +2,9 @@ package tree_sitter_gdscript
 
 // #cgo CFLAGS: -std=c11 -fPIC
 // #include "../../src/parser.c"
-// // NOTE: if your language has an external scanner, add it here.
+// #if __has_include("../../src/scanner.c")
+// #include "../../src/scanner.c"
+// #endif
 import "C"
 
 import "unsafe"

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -2,7 +2,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include <tree_sitter/parser.h>
+#include "tree_sitter/parser.h"
 
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 


### PR DESCRIPTION
Fixes the Go language binding which was missing the external scanner inclusion, causing undefined reference errors when building. Matches the implementation on tree-sitter-python.

https://github.com/tree-sitter/tree-sitter-python/blob/26855eabccb19c6abf499fbc5b8dc7cc9ab8bc64/bindings/go/binding.go#L4C1-L7C10
https://github.com/tree-sitter/tree-sitter-python/blob/26855eabccb19c6abf499fbc5b8dc7cc9ab8bc64/src/scanner.c#L2C1-L2C32

This is the error I was getting before the fix for reference (same issue on Ubuntu, so not nix/NixOS specific):
```
# github.com/prestonknopp/tree-sitter-gdscript/bindings/go.test
/nix/store/3fd683jfggglpshxprz9mi5sz8wd3c9p-go-1.25.0/share/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/nix/store/95k9rsn1zsw1yvir8mj824ldhf90i4qw-gcc-wrapper-14.3.0/bin/gcc -m64 -s -Wl,--build-id=0x0bd5ae09798967e94cfc21299cb43c2f9ffc5c50 -o $WORK/b001/exe/gdscript-linter -Wl,--export-dynamic-symbol=_cgo_panic -Wl,--export-dynamic-symbol=_cgo_topofstack -Wl,--export-dynamic-symbol=crosscall2 -Wl,--export-dynamic-symbol=go_calloc -Wl,--export-dynamic-symbol=go_free -Wl,--export-dynamic-symbol=go_malloc -Wl,--export-dynamic-symbol=go_realloc -Wl,--export-dynamic-symbol=logCallback -Wl,--export-dynamic-symbol=parserProgressCallback -Wl,--export-dynamic-symbol=queryProgressCallback -Wl,--export-dynamic-symbol=readCustomEncoding -Wl,--export-dynamic-symbol=readUTF16BE -Wl,--export-dynamic-symbol=readUTF16LE -Wl,--export-dynamic-symbol=readUTF8 -Wl,--compress-debug-sections=zlib /tmp/go-link-4080697320/go.o /tmp/go-link-4080697320/000000.o /tmp/go-link-4080697320/000001.o /tmp/go-link-4080697320/000002.o /tmp/go-link-4080697320/000003.o /tmp/go-link-4080697320/000004.o /tmp/go-link-4080697320/000005.o /tmp/go-link-4080697320/000006.o /tmp/go-link-4080697320/000007.o /tmp/go-link-4080697320/000008.o /tmp/go-link-4080697320/000009.o /tmp/go-link-4080697320/000010.o /tmp/go-link-4080697320/000011.o /tmp/go-link-4080697320/000012.o /tmp/go-link-4080697320/000013.o /tmp/go-link-4080697320/000014.o /tmp/go-link-4080697320/000015.o /tmp/go-link-4080697320/000016.o /tmp/go-link-4080697320/000017.o /tmp/go-link-4080697320/000018.o /tmp/go-link-4080697320/000019.o /tmp/go-link-4080697320/000020.o /tmp/go-link-4080697320/000021.o /tmp/go-link-4080697320/000022.o /tmp/go-link-4080697320/000023.o /tmp/go-link-4080697320/000024.o /tmp/go-link-4080697320/000025.o /tmp/go-link-4080697320/000026.o /tmp/go-link-4080697320/000027.o /tmp/go-link-4080697320/000028.o /tmp/go-link-4080697320/000029.o /tmp/go-link-4080697320/000030.o /tmp/go-link-4080697320/000031.o /tmp/go-link-4080697320/000032.o /tmp/go-link-4080697320/000033.o /tmp/go-link-4080697320/000034.o /tmp/go-link-4080697320/000035.o /tmp/go-link-4080697320/000036.o /tmp/go-link-4080697320/000037.o /tmp/go-link-4080697320/000038.o -O2 -g -O2 -g -O2 -g -lpthread -O2 -g -O2 -g -lresolv -no-pie
/nix/store/c43ry7z24x3jhnjlj4gpay8a4g2p3x1h-binutils-2.44/bin/ld: /tmp/go-link-4080697320/000001.o:(.data.rel.ro+0xb8): undefined reference to `tree_sitter_gdscript_external_scanner_create'
/nix/store/c43ry7z24x3jhnjlj4gpay8a4g2p3x1h-binutils-2.44/bin/ld: /tmp/go-link-4080697320/000001.o:(.data.rel.ro+0xc0): undefined reference to `tree_sitter_gdscript_external_scanner_destroy'
/nix/store/c43ry7z24x3jhnjlj4gpay8a4g2p3x1h-binutils-2.44/bin/ld: /tmp/go-link-4080697320/000001.o:(.data.rel.ro+0xc8): undefined reference to `tree_sitter_gdscript_external_scanner_scan'
/nix/store/c43ry7z24x3jhnjlj4gpay8a4g2p3x1h-binutils-2.44/bin/ld: /tmp/go-link-4080697320/000001.o:(.data.rel.ro+0xd0): undefined reference to `tree_sitter_gdscript_external_scanner_serialize'
/nix/store/c43ry7z24x3jhnjlj4gpay8a4g2p3x1h-binutils-2.44/bin/ld: /tmp/go-link-4080697320/000001.o:(.data.rel.ro+0xd8): undefined reference to `tree_sitter_gdscript_external_scanner_deserialize'
collect2: error: ld returned 1 exit status

FAIL	github.com/prestonknopp/tree-sitter-gdscript/bindings/go [build failed]
FAIL
```