### PR TITLE
Add support for not followed by await expression

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -562,12 +562,7 @@ module.exports = grammar({
     // -                                  Expressions                              -
     // -----------------------------------------------------------------------------
 
-    _expression: ($) =>
-      choice(
-        $._primary_expression,
-        $.conditional_expression,
-        $.await_expression,
-      ),
+    _expression: ($) => choice($._primary_expression, $.conditional_expression),
 
     _primary_expression: ($) =>
       choice(
@@ -590,6 +585,7 @@ module.exports = grammar({
         $.array,
         $.dictionary,
         $.parenthesized_expression,
+        $.await_expression,
       ),
 
     _rhs_expression: ($) => choice($._expression, $.lambda),

--- a/test/corpus/source.txt
+++ b/test/corpus/source.txt
@@ -246,6 +246,20 @@ func x():
 				(await_expression (attribute (get_node) (identifier)))))))))
 
 =====================================
+Await Not Expression
+=====================================
+
+not await test()
+
+---
+
+(source
+  (expression_statement
+    (unary_operator
+      (await_expression
+        (call (identifier) (arguments))))))
+
+=====================================
 Breakpoint Statement
 =====================================
 


### PR DESCRIPTION
Currently `not await ...` (negating a bool value returned from an async function call) errors out. This PR changes in which expression list await lives to allow parsing this case (unary operator > await expression > call...)
