### PR TITLE
Fix trailing comments after final statement in a function

### DIFF
--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4955,5 +4955,6 @@
     "_primary_expression",
     "_attribute_expression",
     "_parameters"
-  ]
+  ],
+  "reserved": {}
 }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2659,7 +2659,8 @@
   },
   {
     "type": "comment",
-    "named": true
+    "named": true,
+    "extra": true
   },
   {
     "type": "const",
@@ -2731,7 +2732,8 @@
   },
   {
     "type": "line_continuation",
-    "named": true
+    "named": true,
+    "extra": true
   },
   {
     "type": "master",

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -310,9 +310,9 @@ bool tree_sitter_gdscript_external_scanner_scan(void *payload, TSLexer *lexer,
             
             // If we're in a situation where we need to emit a DEDENT first,
             // don't consume the comment - let the DEDENT be processed first
-            if (scanner->indents->len > 0) {
+            if (valid_symbols[DEDENT] && scanner->indents->len > 0) {
                 uint16_t current_indent_length = VEC_BACK(scanner->indents);
-                if (valid_symbols[DEDENT] && indent_length < current_indent_length) {
+                if (indent_length < current_indent_length) {
                     // Don't consume the comment, let the dedent happen first
                     break;
                 }

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -18,6 +18,11 @@ typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
+typedef struct TSLanguageMetadata {
+  uint8_t major_version;
+  uint8_t minor_version;
+  uint8_t patch_version;
+} TSLanguageMetadata;
 #endif
 
 typedef struct {
@@ -26,10 +31,11 @@ typedef struct {
   bool inherited;
 } TSFieldMapEntry;
 
+// Used to index the field and supertype maps.
 typedef struct {
   uint16_t index;
   uint16_t length;
-} TSFieldMapSlice;
+} TSMapSlice;
 
 typedef struct {
   bool visible;
@@ -79,6 +85,12 @@ typedef struct {
   uint16_t external_lex_state;
 } TSLexMode;
 
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+  uint16_t reserved_word_set_id;
+} TSLexerMode;
+
 typedef union {
   TSParseAction action;
   struct {
@@ -93,7 +105,7 @@ typedef struct {
 } TSCharacterRange;
 
 struct TSLanguage {
-  uint32_t version;
+  uint32_t abi_version;
   uint32_t symbol_count;
   uint32_t alias_count;
   uint32_t token_count;
@@ -109,13 +121,13 @@ struct TSLanguage {
   const TSParseActionEntry *parse_actions;
   const char * const *symbol_names;
   const char * const *field_names;
-  const TSFieldMapSlice *field_map_slices;
+  const TSMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;
   const TSSymbol *public_symbol_map;
   const uint16_t *alias_map;
   const TSSymbol *alias_sequences;
-  const TSLexMode *lex_modes;
+  const TSLexerMode *lex_modes;
   bool (*lex_fn)(TSLexer *, TSStateId);
   bool (*keyword_lex_fn)(TSLexer *, TSStateId);
   TSSymbol keyword_capture_token;
@@ -129,15 +141,23 @@ struct TSLanguage {
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
   const TSStateId *primary_state_ids;
+  const char *name;
+  const TSSymbol *reserved_words;
+  uint16_t max_reserved_word_set_size;
+  uint32_t supertype_count;
+  const TSSymbol *supertype_symbols;
+  const TSMapSlice *supertype_map_slices;
+  const TSSymbol *supertype_map_entries;
+  TSLanguageMetadata metadata;
 };
 
-static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+static inline bool set_contains(const TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
   uint32_t index = 0;
   uint32_t size = len - index;
   while (size > 1) {
     uint32_t half_size = size / 2;
     uint32_t mid_index = index + half_size;
-    TSCharacterRange *range = &ranges[mid_index];
+    const TSCharacterRange *range = &ranges[mid_index];
     if (lookahead >= range->start && lookahead <= range->end) {
       return true;
     } else if (lookahead > range->end) {
@@ -145,7 +165,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
     }
     size -= half_size;
   }
-  TSCharacterRange *range = &ranges[index];
+  const TSCharacterRange *range = &ranges[index];
   return (lookahead >= range->start && lookahead <= range->end);
 }
 

--- a/test/corpus/comments.txt
+++ b/test/corpus/comments.txt
@@ -256,3 +256,31 @@ func test():
           (continue_statement)))
       (comment)
       (pass_statement))))
+
+=====================================
+Trailing Comments After Final Statement
+=====================================
+
+func test():
+	pass
+	# comment after final statement
+
+func test2():
+  pass
+  # another comment after final statement
+
+---
+
+(source
+  (function_definition
+    (name)
+    (parameters)
+    (body
+      (pass_statement)
+      (comment)))
+  (function_definition
+      (name)
+      (parameters)
+      (body
+        (pass_statement)
+        (comment))))

--- a/test/corpus/comments.txt
+++ b/test/corpus/comments.txt
@@ -262,8 +262,8 @@ Trailing Comments After Final Statement
 =====================================
 
 func test():
-	pass
-	# comment after final statement
+  pass
+  # comment after final statement
 
 func test2():
   pass


### PR DESCRIPTION
Fixes #62

It feels like this is a little more complex than it needs to be. The problem is definitely inside of `scanner.c`.