### PR TITLE
Fix issues with region parsing

### DIFF
--- a/test/corpus/regions.txt
+++ b/test/corpus/regions.txt
@@ -84,8 +84,8 @@ func _physics_process(delta: float) -> void:
     (body
       (region_start
         (region_label))
-      (pass_statement)))
-  (region_end))
+      (pass_statement)
+      (region_end))))
 
 =====================================
 Region: Two sibling regions


### PR DESCRIPTION
This PR addresses builds upon #71 and addresses one region parsing issue where actually an indented region end comment should not end the function body but be part of the function. This slightly simplifies the scanner.