### PR TITLE
Don't consume comments and re-add special region handling

### DIFF
--- a/test/corpus/comments.txt
+++ b/test/corpus/comments.txt
@@ -265,6 +265,7 @@ func test():
   pass
   # comment after final statement
 
+## docstring comment
 func test2():
   pass
   # another comment after final statement
@@ -278,6 +279,7 @@ func test2():
     (body
       (pass_statement)
       (comment)))
+  (comment)
   (function_definition
       (name)
       (parameters)

--- a/test/corpus/comments.txt
+++ b/test/corpus/comments.txt
@@ -304,3 +304,55 @@ func test():
         (comment)
         (comment)
         (pass_statement))))
+
+=====================================
+Comments: indented comment before string
+=====================================
+
+func test():
+	# comment
+	"hello"
+
+---
+
+(source
+  (function_definition
+    (name)
+    (parameters)
+    (body
+      (comment)
+      (expression_statement
+        (string)))))
+
+=====================================
+Comments: comment before a dictionary key
+=====================================
+
+const TEST_DICTIONARY: Dictionary[String, Dictionary] = {
+	# This is a comment
+	"dictionary_key_1": {
+		# This is another comment
+		"dictionary_key_2": "dictionary_value",
+	},
+}
+
+---
+
+(source
+      (const_statement
+        name: (name)
+        type: (type
+          (subscript
+            (identifier)
+            arguments: (subscript_arguments
+              (identifier)
+              (identifier))))
+        value: (dictionary
+          (comment)
+          (pair
+            left: (string)
+            value: (dictionary
+              (comment)
+              (pair
+                left: (string)
+                value: (string)))))))


### PR DESCRIPTION
Fixes https://github.com/PrestonKnopp/tree-sitter-gdscript/issues/70

This adds back some of the more complex checks that were removed in https://github.com/PrestonKnopp/tree-sitter-gdscript/commit/afba325b009106cb4325dc4e307e6e3d8003de3a and changes it so that comments are no longer consumed by the scanner, which lets the grammar handle them. With the previous change, comments were getting consumed when there was only a string after them (i.e. when creating dictionaries)

I added two new test cases here and made sure that the `#region` / `#endregion` handling that was previously fixed doesn't regress.

Only comments that are at indentation of `0` need the special handling to keep them inside of the function; all other comments will be properly included in the function block that they're inside of.