### PR TITLE
Publish the Python bindings to PyPI

### DIFF
--- a/.github/workflows/publish_python.yml
+++ b/.github/workflows/publish_python.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pypa/cibuildwheel@v4
+      - uses: pypa/cibuildwheel@v4.2.0
         env:
           CIBW_ARCHS: ${{ matrix.archs }}
           # setup.py retags every CPython build as cp39-abi3, so a single build

--- a/.github/workflows/publish_python.yml
+++ b/.github/workflows/publish_python.yml
@@ -1,0 +1,88 @@
+# Builds the Python bindings as abi3 wheels for every platform tree-sitter
+# grammars are normally consumed on, plus an sdist, and publishes them to PyPI
+# when a version tag is pushed.
+#
+# Kept separate from build_publish.yml so the existing npm release path is
+# untouched; both react to the same v* tag, so one tag still cuts one release.
+#
+# One-time setup required before the first tag:
+#   Create a PyPI trusted publisher for this repository at
+#   https://pypi.org/manage/account/publishing/ with
+#     owner = PrestonKnopp, repository = tree-sitter-gdscript,
+#     workflow = publish_python.yml, environment = pypi
+#   No API token or repository secret is needed.
+name: Publish Python
+
+on:
+  push:
+    tags: [v*]
+  workflow_dispatch:
+
+jobs:
+  build_wheels:
+    name: Wheels (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: linux x86_64,  os: ubuntu-latest,    archs: x86_64 }
+          - { name: linux aarch64, os: ubuntu-24.04-arm, archs: aarch64 }
+          - { name: macos x86_64,  os: macos-15-intel,   archs: x86_64 }
+          - { name: macos arm64,   os: macos-latest,     archs: arm64 }
+          # ARM64 is cross-compiled from the x86_64 runner. cibuildwheel cannot
+          # execute an ARM64 wheel there, so it skips the test step for it.
+          - { name: windows,       os: windows-latest,   archs: AMD64 ARM64 }
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pypa/cibuildwheel@v4
+        env:
+          CIBW_ARCHS: ${{ matrix.archs }}
+          # setup.py retags every CPython build as cp39-abi3, so a single build
+          # per platform covers 3.9 and every later version.
+          CIBW_BUILD: cp39-*
+          CIBW_TEST_REQUIRES: tree-sitter
+          CIBW_TEST_COMMAND: python -m unittest discover -s "{project}/bindings/python/tests"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ strategy.job-index }}
+          path: wheelhouse/*.whl
+
+  build_sdist:
+    name: Source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pipx run build --sdist
+      # Prove the sdist can actually rebuild the extension. Without this the
+      # missing-header class of packaging bug only surfaces for users.
+      - name: Install from sdist and load the grammar
+        run: |
+          python -m venv /tmp/sdist-check
+          /tmp/sdist-check/bin/pip install tree-sitter dist/*.tar.gz
+          /tmp/sdist-check/bin/python -m unittest discover -s bindings/python/tests
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+
+  publish:
+    needs: [build_wheels, build_sdist]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # required for PyPI trusted publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: '{wheels-*,sdist}'
+          merge-multiple: true
+      - run: ls -l dist
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,11 @@
+# The sdist must be able to rebuild the extension from scratch. setuptools only
+# auto-includes the files named in Extension(sources=...), which covers
+# src/parser.c, src/scanner.c and the binding, but not the headers they include
+# or the typing marker files.
+recursive-include src/tree_sitter *.h
+recursive-include bindings/python *.pyi py.typed
+include grammar.js tree-sitter.json
+include LICENSE README.md
+
+prune examples
+prune test


### PR DESCRIPTION
The Python bindings in this repo are complete and correct, but they have never been published, so `pip install tree-sitter-gdscript` fails and the name is unclaimed on PyPI. Every other binding here has a distribution channel: node has npm, Rust has crates.io. This adds the missing one.

Two files, nothing existing modified.

### `.github/workflows/publish_python.yml`

Builds abi3 wheels with `cibuildwheel` for macOS x86_64 + arm64, manylinux and musllinux x86_64 + aarch64, and Windows AMD64 + ARM64, plus an sdist, then publishes on the same `v*` tag your npm release already uses. One tag still cuts one release.

I kept it in a separate file rather than adding jobs to `build_publish.yml` so your npm release path is untouched and this is trivial to revert. Happy to fold it into the existing workflow instead if you'd prefer one file.

`setup.py` already retags every CPython build as `cp39-abi3`, so this is one build per platform, not one per Python version. The wheel test step runs the existing `bindings/python/tests/test_binding.py`.

### `MANIFEST.in`

The sdist is currently broken. setuptools only auto-includes the files named in `Extension(sources=...)`, which covers `src/parser.c` and `src/scanner.c` but not the headers they include. Building the current sdist fails:

```
src/parser.c:1:10: fatal error: tree_sitter/parser.h: No such file or directory
```

`MANIFEST.in` adds `src/tree_sitter/*.h` and the `py.typed` / `.pyi` typing markers. The workflow's sdist job installs the built sdist into a clean venv and loads the grammar, so this class of bug can't come back silently.

This is in its own commit if you'd rather take just the fix.

### One-time setup needed before the first tag

The workflow uses PyPI trusted publishing, so there is no API token to create or rotate. It needs a publisher registered once at <https://pypi.org/manage/account/publishing/>:

- PyPI project name: `tree-sitter-gdscript`
- Owner: `PrestonKnopp`
- Repository: `tree-sitter-gdscript`
- Workflow: `publish_python.yml`
- Environment: `pypi`

If you'd rather match the `NPM_TOKEN` pattern you already use, swap the `id-token` permission for a `PYPI_API_TOKEN` secret and I'll update the PR.

### Verification done locally

- Current sdist fails to compile with the missing-header error above (Ubuntu 22.04, gcc 11.4, CPython 3.10).
- With `MANIFEST.in`, the sdist installs clean into a fresh venv and `tree_sitter.Language(tree_sitter_gdscript.language())` returns ABI 14.
- Built with CPython 3.10, the wheel is tagged `tree_sitter_gdscript-6.1.0-cp39-abi3-linux_x86_64`, confirming the abi3 retagging works; `LICENSE` lands in `.dist-info/licenses/`.
- `cibuildwheel --print-build-identifiers` resolves to exactly the six intended targets.

I have not been able to run the Windows or macOS legs locally; those are covered only by the CI matrix.

### Why I'm asking

I maintain [repowise](https://github.com/repowise-dev/repowise), a codebase analysis tool that pins a tree-sitter grammar wheel per supported language. We want to add GDScript and Godot support, and a PyPI wheel is the one missing piece. `tree-sitter-language-pack` isn't an option for us because since 1.0 it downloads grammar shared libraries at runtime, which breaks offline indexing.

We would much rather depend on a package you publish than vendor a copy, so we're offering the workflow rather than forking. No obligation either way, and happy to adjust anything here.
